### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -7,7 +7,7 @@ source /usr/share/yunohost/helpers
 # INITIALIZE AND STORE SETTINGS
 #=================================================
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 #=================================================
 # MODIFY URL IN NGINX CONF

--- a/scripts/install
+++ b/scripts/install
@@ -12,7 +12,7 @@ ynh_app_setting_set --key=redis_db --value="$redis_db"
 # INITIALIZE AND STORE SETTINGS
 #=================================================
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 ynh_app_setting_set --key=timezone --value=$timezone
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -10,7 +10,7 @@ ynh_script_progression --message="Loading additionnal settings..." --weight=1
 
 redis_db=$(ynh_redis_get_free_db)
 ynh_app_setting_set --key=redis_db --value=$redis_db
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 #=================================================
 # RESTORE THE APP MAIN DIR

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -5,7 +5,7 @@ source /usr/share/yunohost/helpers
 
 ynh_app_setting_set_default --key=php_upload_max_filesize --value=1G
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.